### PR TITLE
Work around:

### DIFF
--- a/lib/midi-converter.js
+++ b/lib/midi-converter.js
@@ -35,6 +35,21 @@ module.exports = {
           var noteStr = noteFromMidiPitch(note.noteNumber);
           track.addNoteOff(note.channel, noteStr, note.deltaTime);
         }
+	   else if ( note != 'undefined' && note != null && 
+              note.hasOwnProperty("deltaTime") &&   typeof note.channel !== 'undefined' 
+			        && ( note.channel >= 0 &&  note.channel < 16 ) ) {
+          // Work around: dummy pitchbend (with no bending) instead various controller messages
+          // until proper encoding calls are implemented (probably in jsmidgen)
+          // This is needed in order to maintain correct deltaTime
+          var pitchBend = new Midi.Event(
+            {
+              time:   note.deltaTime,
+              type:   Midi.Event.PITCH_BEND,
+              param1: 0x00, // LSB of centered
+              param2: 0x40  // MSB of centered
+             });
+          track.addEvent(pitchBend);
+        }
       });
     });
 


### PR DESCRIPTION
Added dummy pitchbend (with no bending) instead various controller
messages until proper encoding calls are implemented (probably in jsmidgen).
This is needed in order to maintain correct deltaTime